### PR TITLE
fix: render all vendor registration steps

### DIFF
--- a/src/app/core/features/home/home.html
+++ b/src/app/core/features/home/home.html
@@ -39,14 +39,15 @@
 
       <app-step-b-identity-verification
         *ngIf="currentStep === 'B'"
-        [formGroup]="identityVerificationForm"
+        [form]="identityVerificationForm"
         [onFileSelect]="onFileSelect"
         [goToStep]="goToStep"
       ></app-step-b-identity-verification>
 
       <app-business-details
-        *ngIf="currentStep === 'C'"
+        *ngIf="currentStep === 'C' || currentStep === 'D' || currentStep === 'E'"
         [vendorForm]="vendorForm"
+        [currentStep]="currentStep"
         (goToStep)="goToStep($event)"
         (finalSubmit)="onFinalSubmit()"
       ></app-business-details>

--- a/src/app/core/features/home/steps/step-a-basic-info/step-a-basic-info.spec.ts
+++ b/src/app/core/features/home/steps/step-a-basic-info/step-a-basic-info.spec.ts
@@ -1,21 +1,21 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { StepABasicInfo } from './step-a-basic-info';
+import { StepABasicInfoComponent } from './step-a-basic-info';
 
-describe('StepABasicInfo', () => {
-  let component: StepABasicInfo;
-  let fixture: ComponentFixture<StepABasicInfo>;
+describe('StepABasicInfoComponent', () => {
+  let component: StepABasicInfoComponent;
+  let fixture: ComponentFixture<StepABasicInfoComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [StepABasicInfo]
-    })
+      await TestBed.configureTestingModule({
+        imports: [StepABasicInfoComponent]
+      })
     .compileComponents();
 
-    fixture = TestBed.createComponent(StepABasicInfo);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+      fixture = TestBed.createComponent(StepABasicInfoComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/core/features/home/steps/step-b-identity-verification/step-b-identity-verification.html
+++ b/src/app/core/features/home/steps/step-b-identity-verification/step-b-identity-verification.html
@@ -1,4 +1,4 @@
-<div [formGroup]="formGroup" class="form-section">
+<div [formGroup]="form" class="form-section">
     <h2>Step B: Identity Verification</h2>
     <div class="form-grid">
       <mat-form-field appearance="outline" class="full-width">
@@ -27,10 +27,10 @@
       </div>
     </div>
   
-    <div class="step-buttons">
-      <button mat-stroked-button color="primary" (click)="goToStep('A')">Back</button>
-      <button mat-flat-button color="primary" (click)="goToStep('C')" [disabled]="formGroup.invalid">
-        Next
-      </button>
-    </div>
+      <div class="step-buttons">
+        <button mat-stroked-button color="primary" (click)="goToStep('A')">Back</button>
+        <button mat-flat-button color="primary" (click)="goToStep('C')" [disabled]="form.invalid">
+          Next
+        </button>
+      </div>
   </div>

--- a/src/app/core/features/home/steps/step-b-identity-verification/step-b-identity-verification.spec.ts
+++ b/src/app/core/features/home/steps/step-b-identity-verification/step-b-identity-verification.spec.ts
@@ -1,21 +1,21 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { StepBIdentityVerification } from './step-b-identity-verification';
+import { StepBIdentityVerificationComponent } from './step-b-identity-verification';
 
-describe('StepBIdentityVerification', () => {
-  let component: StepBIdentityVerification;
-  let fixture: ComponentFixture<StepBIdentityVerification>;
+describe('StepBIdentityVerificationComponent', () => {
+  let component: StepBIdentityVerificationComponent;
+  let fixture: ComponentFixture<StepBIdentityVerificationComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [StepBIdentityVerification]
-    })
+      await TestBed.configureTestingModule({
+        imports: [StepBIdentityVerificationComponent]
+      })
     .compileComponents();
 
-    fixture = TestBed.createComponent(StepBIdentityVerification);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+      fixture = TestBed.createComponent(StepBIdentityVerificationComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/core/features/home/steps/step-b-identity-verification/step-b-identity-verification.ts
+++ b/src/app/core/features/home/steps/step-b-identity-verification/step-b-identity-verification.ts
@@ -20,7 +20,7 @@ import { MatButtonModule } from '@angular/material/button';
   styleUrls: ['./step-b-identity-verification.css']
 })
 export class StepBIdentityVerificationComponent {
-  @Input() formGroup!: FormGroup;
+  @Input() form!: FormGroup;
   @Input() onFileSelect!: (event: Event, field: string) => void;
- @Input() goToStep!: (step: 'A' | 'B' | 'C' | 'D' | 'E') => void;
+  @Input() goToStep!: (step: 'A' | 'B' | 'C' | 'D' | 'E') => void;
 }

--- a/src/app/core/features/home/steps/step-c-business-details/step-c-business-details.html
+++ b/src/app/core/features/home/steps/step-c-business-details/step-c-business-details.html
@@ -1,108 +1,118 @@
 <div [formGroup]="vendorForm">
-    <!-- STEP C: Business Details -->
-    <div formGroupName="businessDetails">
-      <h2>Step C: Business Details</h2>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Select Your Category</mat-label>
-        <mat-select formControlName="category">
-          <mat-option value="Homes">Homes</mat-option>
-          <mat-option value="Beauty">Beauty</mat-option>
-          <mat-option value="Pandit Jee">Pandit Jee</mat-option>
-        </mat-select>
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Select Your Profession</mat-label>
-        <mat-select formControlName="profession">
-          <mat-option *ngFor="let option of filteredProfessions" [value]="option">
-            {{ option }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Select Services Offered</mat-label>
-        <mat-select formControlName="servicesOffered" multiple>
-          <mat-option *ngFor="let service of filteredServices" [value]="service">
-            {{ service }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Years of Experience</mat-label>
-        <mat-select formControlName="experience">
-          <mat-option value="<1 year">&lt; 1 year</mat-option>
-          <mat-option value="1-2 years">1–2 years</mat-option>
-          <mat-option value="2-3 years">2–3 years</mat-option>
-          <mat-option value="3-4 years">3–4 years</mat-option>
-          <mat-option value=">4 years">&gt; 4 years</mat-option>
-        </mat-select>
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Upload Experience/Certifications</mat-label>
-        <input matInput type="file" (change)="onFileSelect($event, 'businessDetails.experienceCertUrl')" />
-      </mat-form-field>
-    </div>
-  
-    <hr />
-  
-    <!-- STEP D: Availability -->
-    <div formGroupName="availability">
-      <h2>Step D: Availability</h2>
-  
-      <div formGroupName="workingHours" class="time-row">
-        <mat-form-field appearance="fill" class="half-width">
-          <mat-label>Start Time</mat-label>
-          <input matInput formControlName="start" placeholder="e.g., 10:00 AM" />
-        </mat-form-field>
-  
-        <mat-form-field appearance="fill" class="half-width">
-          <mat-label>End Time</mat-label>
-          <input matInput formControlName="end" placeholder="e.g., 6:00 PM" />
-        </mat-form-field>
-      </div>
-  
-      <label>Emergency/On-Call Service</label>
-      <mat-radio-group formControlName="onCallEmergency">
-        <mat-radio-button [value]="true">Yes</mat-radio-button>
-        <mat-radio-button [value]="false">No</mat-radio-button>
-      </mat-radio-group>
-    </div>
-  
-    <hr />
-  
-    <!-- STEP E: Payment Details -->
-    <div formGroupName="paymentDetails">
-      <h2>Step E: Payment Information</h2>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Account Holder Name</mat-label>
-        <input matInput formControlName="accountHolderName" />
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Account Number</mat-label>
-        <input matInput formControlName="accountNumber" />
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>IFSC Code</mat-label>
-        <input matInput formControlName="ifscCode" />
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>UPI ID (Optional)</mat-label>
-        <input matInput formControlName="upiId" />
-      </mat-form-field>
-    </div>
-  
+  <!-- STEP C: Business Details -->
+  <div *ngIf="currentStep === 'C'" formGroupName="businessDetails">
+    <h2>Step C: Business Details</h2>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Select Your Category</mat-label>
+      <mat-select formControlName="category">
+        <mat-option value="Homes">Homes</mat-option>
+        <mat-option value="Beauty">Beauty</mat-option>
+        <mat-option value="Pandit Jee">Pandit Jee</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Select Your Profession</mat-label>
+      <mat-select formControlName="profession">
+        <mat-option *ngFor="let option of filteredProfessions" [value]="option">
+          {{ option }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Select Services Offered</mat-label>
+      <mat-select formControlName="servicesOffered" multiple>
+        <mat-option *ngFor="let service of filteredServices" [value]="service">
+          {{ service }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Years of Experience</mat-label>
+      <mat-select formControlName="experience">
+        <mat-option value="<1 year">&lt; 1 year</mat-option>
+        <mat-option value="1-2 years">1–2 years</mat-option>
+        <mat-option value="2-3 years">2–3 years</mat-option>
+        <mat-option value="3-4 years">3–4 years</mat-option>
+        <mat-option value=">4 years">&gt; 4 years</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Upload Experience/Certifications</mat-label>
+      <input matInput type="file" (change)="onFileSelect($event, 'businessDetails.experienceCertUrl')" />
+    </mat-form-field>
+
     <div class="button-group">
-      <button mat-stroked-button color="primary" (click)="goBack()">Back</button>
-      <button mat-raised-button color="primary" (click)="onFinalSubmit()" [disabled]="!vendorForm.valid">
+      <button mat-stroked-button color="primary" (click)="goToStep.emit('B')">Back</button>
+      <button mat-raised-button color="primary" (click)="goToStep.emit('D')" [disabled]="vendorForm.get('businessDetails')?.invalid">
+        Next
+      </button>
+    </div>
+  </div>
+
+  <!-- STEP D: Availability -->
+  <div *ngIf="currentStep === 'D'" formGroupName="availability">
+    <h2>Step D: Availability</h2>
+
+    <div formGroupName="workingHours" class="time-row">
+      <mat-form-field appearance="fill" class="half-width">
+        <mat-label>Start Time</mat-label>
+        <input matInput formControlName="start" placeholder="e.g., 10:00 AM" />
+      </mat-form-field>
+
+      <mat-form-field appearance="fill" class="half-width">
+        <mat-label>End Time</mat-label>
+        <input matInput formControlName="end" placeholder="e.g., 6:00 PM" />
+      </mat-form-field>
+    </div>
+
+    <label>Emergency/On-Call Service</label>
+    <mat-radio-group formControlName="onCallEmergency">
+      <mat-radio-button [value]="true">Yes</mat-radio-button>
+      <mat-radio-button [value]="false">No</mat-radio-button>
+    </mat-radio-group>
+
+    <div class="button-group">
+      <button mat-stroked-button color="primary" (click)="goToStep.emit('C')">Back</button>
+      <button mat-raised-button color="primary" (click)="goToStep.emit('E')" [disabled]="vendorForm.get('availability')?.invalid">
+        Next
+      </button>
+    </div>
+  </div>
+
+  <!-- STEP E: Payment Details -->
+  <div *ngIf="currentStep === 'E'" formGroupName="paymentDetails">
+    <h2>Step E: Payment Information</h2>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Account Holder Name</mat-label>
+      <input matInput formControlName="accountHolderName" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Account Number</mat-label>
+      <input matInput formControlName="accountNumber" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>IFSC Code</mat-label>
+      <input matInput formControlName="ifscCode" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>UPI ID (Optional)</mat-label>
+      <input matInput formControlName="upiId" />
+    </mat-form-field>
+
+    <div class="button-group">
+      <button mat-stroked-button color="primary" (click)="goToStep.emit('D')">Back</button>
+      <button mat-raised-button color="primary" (click)="onFinalSubmit()" [disabled]="vendorForm.get('paymentDetails')?.invalid">
         Submit
       </button>
     </div>
   </div>
+</div>

--- a/src/app/core/features/home/steps/step-c-business-details/step-c-business-details.spec.ts
+++ b/src/app/core/features/home/steps/step-c-business-details/step-c-business-details.spec.ts
@@ -1,21 +1,21 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { StepCBusinessDetails } from './step-c-business-details';
+import { BusinessDetailsComponent } from './step-c-business-details';
 
-describe('StepCBusinessDetails', () => {
-  let component: StepCBusinessDetails;
-  let fixture: ComponentFixture<StepCBusinessDetails>;
+describe('BusinessDetailsComponent', () => {
+  let component: BusinessDetailsComponent;
+  let fixture: ComponentFixture<BusinessDetailsComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [StepCBusinessDetails]
-    })
+      await TestBed.configureTestingModule({
+        imports: [BusinessDetailsComponent]
+      })
     .compileComponents();
 
-    fixture = TestBed.createComponent(StepCBusinessDetails);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+      fixture = TestBed.createComponent(BusinessDetailsComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/core/features/home/steps/step-c-business-details/step-c-business-details.ts
+++ b/src/app/core/features/home/steps/step-c-business-details/step-c-business-details.ts
@@ -27,6 +27,7 @@ import { MatButtonModule } from '@angular/material/button';
 })
 export class BusinessDetailsComponent implements OnInit {
   @Input() vendorForm!: FormGroup;
+  @Input() currentStep: 'C' | 'D' | 'E' = 'C';
   @Output() goToStep = new EventEmitter<'A' | 'B' | 'C' | 'D' | 'E'>();
   @Output() finalSubmit = new EventEmitter<void>();
 
@@ -76,9 +77,5 @@ export class BusinessDetailsComponent implements OnInit {
     } else {
       this.vendorForm.markAllAsTouched();
     }
-  }
-
-  goBack() {
-    this.goToStep.emit('B');
   }
 }


### PR DESCRIPTION
## Summary
- Ensure step components accept FormGroup inputs and navigation works
- Render business details, availability, and payment in one component based on current step
- Update unit test specs for new component names

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run build` *(fails: Inlining of fonts returned status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_688efec710188331b9a408e275e969be