### PR TITLE
fix: render all vendor registration steps

### DIFF
--- a/src/app/core/features/home/home.html
+++ b/src/app/core/features/home/home.html
@@ -34,22 +34,28 @@
         *ngIf="currentStep === 'A'"
         [form]="basicInfoForm"
         (next)="goToStep('B')"
-        (fileSelected)="onFileSelect($event, 'profilePhotoUrl')"
       ></app-step-a-basic-info>
 
       <app-step-b-identity-verification
         *ngIf="currentStep === 'B'"
-        [formGroup]="identityVerificationForm"
+        [form]="identityVerificationForm"
         [onFileSelect]="onFileSelect"
         [goToStep]="goToStep"
       ></app-step-b-identity-verification>
 
       <app-business-details
-        *ngIf="currentStep === 'C'"
+        *ngIf="currentStep === 'C' || currentStep === 'D'"
         [vendorForm]="vendorForm"
+        [currentStep]="currentStep"
         (goToStep)="goToStep($event)"
-        (finalSubmit)="onFinalSubmit()"
       ></app-business-details>
+
+      <app-step-e-payment
+        *ngIf="currentStep === 'E'"
+        [form]="paymentDetailsForm"
+        (previous)="goToStep('D')"
+        (submit)="onFinalSubmit()"
+      ></app-step-e-payment>
     </form>
   </div>
 </div>

--- a/src/app/core/features/home/home.ts
+++ b/src/app/core/features/home/home.ts
@@ -17,6 +17,7 @@ import { Router } from '@angular/router';
 import { StepABasicInfoComponent } from './steps/step-a-basic-info/step-a-basic-info';
 import { StepBIdentityVerificationComponent } from './steps/step-b-identity-verification/step-b-identity-verification';
 import { BusinessDetailsComponent } from './steps/step-c-business-details/step-c-business-details';
+import { StepEPaymentComponent } from './steps/step-e-payment/step-e-payment';
 
 @Component({
   selector: 'app-home',
@@ -38,7 +39,8 @@ import { BusinessDetailsComponent } from './steps/step-c-business-details/step-c
     MatSnackBarModule,
     StepABasicInfoComponent,
     StepBIdentityVerificationComponent,
-    BusinessDetailsComponent
+    BusinessDetailsComponent,
+    StepEPaymentComponent
   ]
 })
 export class HomeComponent {
@@ -107,6 +109,10 @@ export class HomeComponent {
   
   get identityVerificationForm(): FormGroup {
     return this.vendorForm.get('identityVerification') as FormGroup;
+  }
+
+  get paymentDetailsForm(): FormGroup {
+    return this.vendorForm.get('paymentDetails') as FormGroup;
   }
 
   handleToggleChange() {

--- a/src/app/core/features/home/steps/step-a-basic-info/step-a-basic-info.html
+++ b/src/app/core/features/home/steps/step-a-basic-info/step-a-basic-info.html
@@ -50,7 +50,7 @@
   
     <mat-form-field appearance="fill" class="full-width">
       <mat-label>Upload Profile Photo</mat-label>
-      <input matInput type="file" (change)="onFileChange($event)" />
+      <input type="file" formControlName="profilePhotoUrl" (change)="onFileChange($event)" />
     </mat-form-field>
   
     <button mat-raised-button color="primary" (click)="next.emit()" [disabled]="form.invalid">

--- a/src/app/core/features/home/steps/step-a-basic-info/step-a-basic-info.spec.ts
+++ b/src/app/core/features/home/steps/step-a-basic-info/step-a-basic-info.spec.ts
@@ -1,21 +1,21 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { StepABasicInfo } from './step-a-basic-info';
+import { StepABasicInfoComponent } from './step-a-basic-info';
 
-describe('StepABasicInfo', () => {
-  let component: StepABasicInfo;
-  let fixture: ComponentFixture<StepABasicInfo>;
+describe('StepABasicInfoComponent', () => {
+  let component: StepABasicInfoComponent;
+  let fixture: ComponentFixture<StepABasicInfoComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [StepABasicInfo]
-    })
+      await TestBed.configureTestingModule({
+        imports: [StepABasicInfoComponent]
+      })
     .compileComponents();
 
-    fixture = TestBed.createComponent(StepABasicInfo);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+      fixture = TestBed.createComponent(StepABasicInfoComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/core/features/home/steps/step-a-basic-info/step-a-basic-info.ts
+++ b/src/app/core/features/home/steps/step-a-basic-info/step-a-basic-info.ts
@@ -21,9 +21,12 @@ import { MatButtonModule } from '@angular/material/button';
 export class StepABasicInfoComponent {
   @Input() form!: FormGroup;
   @Output() next = new EventEmitter<void>();
-  @Output() fileSelected = new EventEmitter<any>();
 
-  onFileChange(event: any): void {
-    this.fileSelected.emit(event);
+  onFileChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input?.files?.[0];
+    if (file) {
+      this.form.get('profilePhotoUrl')?.setValue(file.name);
+    }
   }
 }

--- a/src/app/core/features/home/steps/step-b-identity-verification/step-b-identity-verification.html
+++ b/src/app/core/features/home/steps/step-b-identity-verification/step-b-identity-verification.html
@@ -1,4 +1,4 @@
-<div [formGroup]="formGroup" class="form-section">
+<div [formGroup]="form" class="form-section">
     <h2>Step B: Identity Verification</h2>
     <div class="form-grid">
       <mat-form-field appearance="outline" class="full-width">
@@ -27,10 +27,10 @@
       </div>
     </div>
   
-    <div class="step-buttons">
-      <button mat-stroked-button color="primary" (click)="goToStep('A')">Back</button>
-      <button mat-flat-button color="primary" (click)="goToStep('C')" [disabled]="formGroup.invalid">
-        Next
-      </button>
-    </div>
+      <div class="step-buttons">
+        <button mat-stroked-button color="primary" (click)="goToStep('A')">Back</button>
+        <button mat-flat-button color="primary" (click)="goToStep('C')" [disabled]="form.invalid">
+          Next
+        </button>
+      </div>
   </div>

--- a/src/app/core/features/home/steps/step-b-identity-verification/step-b-identity-verification.spec.ts
+++ b/src/app/core/features/home/steps/step-b-identity-verification/step-b-identity-verification.spec.ts
@@ -1,21 +1,21 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { StepBIdentityVerification } from './step-b-identity-verification';
+import { StepBIdentityVerificationComponent } from './step-b-identity-verification';
 
-describe('StepBIdentityVerification', () => {
-  let component: StepBIdentityVerification;
-  let fixture: ComponentFixture<StepBIdentityVerification>;
+describe('StepBIdentityVerificationComponent', () => {
+  let component: StepBIdentityVerificationComponent;
+  let fixture: ComponentFixture<StepBIdentityVerificationComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [StepBIdentityVerification]
-    })
+      await TestBed.configureTestingModule({
+        imports: [StepBIdentityVerificationComponent]
+      })
     .compileComponents();
 
-    fixture = TestBed.createComponent(StepBIdentityVerification);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+      fixture = TestBed.createComponent(StepBIdentityVerificationComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/core/features/home/steps/step-b-identity-verification/step-b-identity-verification.ts
+++ b/src/app/core/features/home/steps/step-b-identity-verification/step-b-identity-verification.ts
@@ -20,7 +20,7 @@ import { MatButtonModule } from '@angular/material/button';
   styleUrls: ['./step-b-identity-verification.css']
 })
 export class StepBIdentityVerificationComponent {
-  @Input() formGroup!: FormGroup;
+  @Input() form!: FormGroup;
   @Input() onFileSelect!: (event: Event, field: string) => void;
- @Input() goToStep!: (step: 'A' | 'B' | 'C' | 'D' | 'E') => void;
+  @Input() goToStep!: (step: 'A' | 'B' | 'C' | 'D' | 'E') => void;
 }

--- a/src/app/core/features/home/steps/step-c-business-details/step-c-business-details.html
+++ b/src/app/core/features/home/steps/step-c-business-details/step-c-business-details.html
@@ -1,108 +1,87 @@
 <div [formGroup]="vendorForm">
-    <!-- STEP C: Business Details -->
-    <div formGroupName="businessDetails">
-      <h2>Step C: Business Details</h2>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Select Your Category</mat-label>
-        <mat-select formControlName="category">
-          <mat-option value="Homes">Homes</mat-option>
-          <mat-option value="Beauty">Beauty</mat-option>
-          <mat-option value="Pandit Jee">Pandit Jee</mat-option>
-        </mat-select>
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Select Your Profession</mat-label>
-        <mat-select formControlName="profession">
-          <mat-option *ngFor="let option of filteredProfessions" [value]="option">
-            {{ option }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Select Services Offered</mat-label>
-        <mat-select formControlName="servicesOffered" multiple>
-          <mat-option *ngFor="let service of filteredServices" [value]="service">
-            {{ service }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Years of Experience</mat-label>
-        <mat-select formControlName="experience">
-          <mat-option value="<1 year">&lt; 1 year</mat-option>
-          <mat-option value="1-2 years">1–2 years</mat-option>
-          <mat-option value="2-3 years">2–3 years</mat-option>
-          <mat-option value="3-4 years">3–4 years</mat-option>
-          <mat-option value=">4 years">&gt; 4 years</mat-option>
-        </mat-select>
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Upload Experience/Certifications</mat-label>
-        <input matInput type="file" (change)="onFileSelect($event, 'businessDetails.experienceCertUrl')" />
-      </mat-form-field>
-    </div>
-  
-    <hr />
-  
-    <!-- STEP D: Availability -->
-    <div formGroupName="availability">
-      <h2>Step D: Availability</h2>
-  
-      <div formGroupName="workingHours" class="time-row">
-        <mat-form-field appearance="fill" class="half-width">
-          <mat-label>Start Time</mat-label>
-          <input matInput formControlName="start" placeholder="e.g., 10:00 AM" />
-        </mat-form-field>
-  
-        <mat-form-field appearance="fill" class="half-width">
-          <mat-label>End Time</mat-label>
-          <input matInput formControlName="end" placeholder="e.g., 6:00 PM" />
-        </mat-form-field>
-      </div>
-  
-      <label>Emergency/On-Call Service</label>
-      <mat-radio-group formControlName="onCallEmergency">
-        <mat-radio-button [value]="true">Yes</mat-radio-button>
-        <mat-radio-button [value]="false">No</mat-radio-button>
-      </mat-radio-group>
-    </div>
-  
-    <hr />
-  
-    <!-- STEP E: Payment Details -->
-    <div formGroupName="paymentDetails">
-      <h2>Step E: Payment Information</h2>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Account Holder Name</mat-label>
-        <input matInput formControlName="accountHolderName" />
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Account Number</mat-label>
-        <input matInput formControlName="accountNumber" />
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>IFSC Code</mat-label>
-        <input matInput formControlName="ifscCode" />
-      </mat-form-field>
-  
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>UPI ID (Optional)</mat-label>
-        <input matInput formControlName="upiId" />
-      </mat-form-field>
-    </div>
-  
+  <!-- STEP C: Business Details -->
+  <div *ngIf="currentStep === 'C'" formGroupName="businessDetails">
+    <h2>Step C: Business Details</h2>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Select Your Category</mat-label>
+      <mat-select formControlName="category">
+        <mat-option value="Homes">Homes</mat-option>
+        <mat-option value="Beauty">Beauty</mat-option>
+        <mat-option value="Pandit Jee">Pandit Jee</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Select Your Profession</mat-label>
+      <mat-select formControlName="profession">
+        <mat-option *ngFor="let option of filteredProfessions" [value]="option">
+          {{ option }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Select Services Offered</mat-label>
+      <mat-select formControlName="servicesOffered" multiple>
+        <mat-option *ngFor="let service of filteredServices" [value]="service">
+          {{ service }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Years of Experience</mat-label>
+      <mat-select formControlName="experience">
+        <mat-option value="<1 year">&lt; 1 year</mat-option>
+        <mat-option value="1-2 years">1–2 years</mat-option>
+        <mat-option value="2-3 years">2–3 years</mat-option>
+        <mat-option value="3-4 years">3–4 years</mat-option>
+        <mat-option value=">4 years">&gt; 4 years</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Upload Experience/Certifications</mat-label>
+      <input matInput type="file" (change)="onFileSelect($event, 'businessDetails.experienceCertUrl')" />
+    </mat-form-field>
+
     <div class="button-group">
-      <button mat-stroked-button color="primary" (click)="goBack()">Back</button>
-      <button mat-raised-button color="primary" (click)="onFinalSubmit()" [disabled]="!vendorForm.valid">
-        Submit
+      <button mat-stroked-button color="primary" (click)="goToStep.emit('B')">Back</button>
+      <button mat-raised-button color="primary" (click)="goToStep.emit('D')" [disabled]="vendorForm.get('businessDetails')?.invalid">
+        Next
       </button>
     </div>
   </div>
+
+  <!-- STEP D: Availability -->
+  <div *ngIf="currentStep === 'D'" formGroupName="availability">
+    <h2>Step D: Availability</h2>
+
+    <div formGroupName="workingHours" class="time-row">
+      <mat-form-field appearance="fill" class="half-width">
+        <mat-label>Start Time</mat-label>
+        <input matInput formControlName="start" placeholder="e.g., 10:00 AM" />
+      </mat-form-field>
+
+      <mat-form-field appearance="fill" class="half-width">
+        <mat-label>End Time</mat-label>
+        <input matInput formControlName="end" placeholder="e.g., 6:00 PM" />
+      </mat-form-field>
+    </div>
+
+    <label>Emergency/On-Call Service</label>
+    <mat-radio-group formControlName="onCallEmergency">
+      <mat-radio-button [value]="true">Yes</mat-radio-button>
+      <mat-radio-button [value]="false">No</mat-radio-button>
+    </mat-radio-group>
+
+    <div class="button-group">
+      <button mat-stroked-button color="primary" (click)="goToStep.emit('C')">Back</button>
+      <button mat-raised-button color="primary" (click)="goToStep.emit('E')" [disabled]="vendorForm.get('availability')?.invalid">
+        Next
+      </button>
+    </div>
+  </div>
+
+</div>

--- a/src/app/core/features/home/steps/step-c-business-details/step-c-business-details.spec.ts
+++ b/src/app/core/features/home/steps/step-c-business-details/step-c-business-details.spec.ts
@@ -1,21 +1,21 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { StepCBusinessDetails } from './step-c-business-details';
+import { BusinessDetailsComponent } from './step-c-business-details';
 
-describe('StepCBusinessDetails', () => {
-  let component: StepCBusinessDetails;
-  let fixture: ComponentFixture<StepCBusinessDetails>;
+describe('BusinessDetailsComponent', () => {
+  let component: BusinessDetailsComponent;
+  let fixture: ComponentFixture<BusinessDetailsComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [StepCBusinessDetails]
-    })
+      await TestBed.configureTestingModule({
+        imports: [BusinessDetailsComponent]
+      })
     .compileComponents();
 
-    fixture = TestBed.createComponent(StepCBusinessDetails);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+      fixture = TestBed.createComponent(BusinessDetailsComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/core/features/home/steps/step-c-business-details/step-c-business-details.ts
+++ b/src/app/core/features/home/steps/step-c-business-details/step-c-business-details.ts
@@ -27,8 +27,8 @@ import { MatButtonModule } from '@angular/material/button';
 })
 export class BusinessDetailsComponent implements OnInit {
   @Input() vendorForm!: FormGroup;
+  @Input() currentStep: 'C' | 'D' = 'C';
   @Output() goToStep = new EventEmitter<'A' | 'B' | 'C' | 'D' | 'E'>();
-  @Output() finalSubmit = new EventEmitter<void>();
 
   filteredProfessions: string[] = [];
   filteredServices: string[] = [];
@@ -68,17 +68,5 @@ export class BusinessDetailsComponent implements OnInit {
     if (file) {
       this.vendorForm.get(controlPath)?.setValue(file.name); // Replace with actual URL logic if needed
     }
-  }
-
-  onFinalSubmit() {
-    if (this.vendorForm.valid) {
-      this.finalSubmit.emit();
-    } else {
-      this.vendorForm.markAllAsTouched();
-    }
-  }
-
-  goBack() {
-    this.goToStep.emit('B');
   }
 }

--- a/src/app/core/features/home/steps/step-e-payment/step-e-payment.css
+++ b/src/app/core/features/home/steps/step-e-payment/step-e-payment.css
@@ -1,0 +1,9 @@
+.button-group {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 16px;
+}
+
+.full-width {
+  width: 100%;
+}

--- a/src/app/core/features/home/steps/step-e-payment/step-e-payment.html
+++ b/src/app/core/features/home/steps/step-e-payment/step-e-payment.html
@@ -1,0 +1,28 @@
+<div [formGroup]="form">
+  <h2>Step E: Payment Information</h2>
+
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>Account Holder Name</mat-label>
+    <input matInput formControlName="accountHolderName" />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>Account Number</mat-label>
+    <input matInput formControlName="accountNumber" />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>IFSC Code</mat-label>
+    <input matInput formControlName="ifscCode" />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>UPI ID (Optional)</mat-label>
+    <input matInput formControlName="upiId" />
+  </mat-form-field>
+
+  <div class="button-group">
+    <button mat-stroked-button color="primary" (click)="previous.emit()">Back</button>
+    <button mat-raised-button color="primary" (click)="submit.emit()" [disabled]="form.invalid">Submit</button>
+  </div>
+</div>

--- a/src/app/core/features/home/steps/step-e-payment/step-e-payment.spec.ts
+++ b/src/app/core/features/home/steps/step-e-payment/step-e-payment.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StepEPaymentComponent } from './step-e-payment';
+
+describe('StepEPaymentComponent', () => {
+  let component: StepEPaymentComponent;
+  let fixture: ComponentFixture<StepEPaymentComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StepEPaymentComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StepEPaymentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/core/features/home/steps/step-e-payment/step-e-payment.ts
+++ b/src/app/core/features/home/steps/step-e-payment/step-e-payment.ts
@@ -1,0 +1,19 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-step-e-payment',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatButtonModule],
+  templateUrl: './step-e-payment.html',
+  styleUrls: ['./step-e-payment.css']
+})
+export class StepEPaymentComponent {
+  @Input() form!: FormGroup;
+  @Output() previous = new EventEmitter<void>();
+  @Output() submit = new EventEmitter<void>();
+}


### PR DESCRIPTION
## Summary
- Bind Basic Info profile photo input to `profilePhotoUrl` and remove unused file output
- Isolate payment details into new `StepEPaymentComponent` and limit business-details to steps C–D
- Update home component to include new payment step and getter for `paymentDetails`

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform. Please, set "CHROME_BIN" env variable.)*
- `npm run build` *(fails: Inlining of fonts failed. https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap returned status code: 403.)*

------
https://chatgpt.com/codex/tasks/task_e_688efec710188331b9a408e275e969be